### PR TITLE
Fix - polyfill source methods

### DIFF
--- a/dist/webpack/WindowAssignPropertiesPlugin.js
+++ b/dist/webpack/WindowAssignPropertiesPlugin.js
@@ -61,7 +61,18 @@ class WindowAssignPropertiesPlugin {
                 .join(`\n${lineStart}`);
             return `${assignments}\n${lineStart}window${arrayPath}`;
         });
-        return new webpack_sources_1.RawSource(updatedSource);
+        const newSource = new webpack_sources_1.RawSource(updatedSource);
+        /**
+         * Hack: depending on the loaded `webpack-sources` package, the `RawSource` class definition might contain or not
+         * the `buffer` and `isBuffer` methods. If the class does not contain them, then we polyfill them.
+         */
+        if (typeof newSource.buffer !== "function") {
+            newSource.buffer = () => Buffer.from(updatedSource, "utf-8");
+        }
+        if (typeof newSource.isBuffer !== "function") {
+            newSource.isBuffer = () => true;
+        }
+        return newSource;
     }
     processAssets(assets) {
         Object.entries(assets).forEach(([pathname, source]) => {

--- a/src/webpack/WindowAssignPropertiesPlugin.ts
+++ b/src/webpack/WindowAssignPropertiesPlugin.ts
@@ -1,4 +1,4 @@
-import { RawSource, Source } from "webpack-sources";
+import { Source, RawSource } from "webpack-sources";
 import { WindowAssignPropertiesPluginOptions } from "../types/WindowAssignPropertiesPluginOptions";
 
 export class WindowAssignPropertiesPlugin {
@@ -80,7 +80,19 @@ export class WindowAssignPropertiesPlugin {
       },
     );
 
-    return new RawSource(updatedSource);
+    const newSource = new RawSource(updatedSource);
+    /**
+     * Hack: depending on the loaded `webpack-sources` package, the `RawSource` class definition might contain or not
+     * the `buffer` and `isBuffer` methods. If the class does not contain them, then we polyfill them.
+     */
+    if (typeof newSource.buffer !== "function") {
+      newSource.buffer = () => Buffer.from(updatedSource, "utf-8");
+    }
+    if (typeof newSource.isBuffer !== "function") {
+      newSource.isBuffer = () => true;
+    }
+
+    return newSource;
   }
 
   public processAssets(assets: { [key in string]: Source }) {


### PR DESCRIPTION
Depending on the `wepback-sources` version loaded, anything between `1.4.3` and `3.2.3`; the `RawSource` class definition might contain the `buffer()` and `isBuffer()` methods or not.
To make the plugin work in both instances, polyfill the methods if not defined.

I've tested the build locally with:

```bash
 npm i https://github.com/stellarwp/tyson#fix/source-buffer
```