### PR TITLE
fix(isPackageRoot) store discovered package roots correctly

### DIFF
--- a/dist/functions/isPackageRootIndex.js
+++ b/dist/functions/isPackageRootIndex.js
@@ -48,7 +48,9 @@ function resetDiscoveredPackageRoots() {
  * @param {string} packageRoot The package root to add.
  */
 function addToDiscoveredPackageRoots(packageRoot) {
-    discoveredPackageRoots.push(packageRoot);
+    // Remove any leading and trailing slashes from the package root.
+    const cleanRoot = packageRoot.replace(/^\/+|\/+$/g, "");
+    discoveredPackageRoots.push(cleanRoot);
 }
 /**
  * Returns the package roots discovered so far.

--- a/src/functions/isPackageRootIndex.ts
+++ b/src/functions/isPackageRootIndex.ts
@@ -47,7 +47,9 @@ export function resetDiscoveredPackageRoots(): void {
  * @param {string} packageRoot The package root to add.
  */
 export function addToDiscoveredPackageRoots(packageRoot: string): void {
-  discoveredPackageRoots.push(packageRoot);
+  // Remove any leading and trailing slashes from the package root.
+  const cleanRoot = packageRoot.replace(/^\/+|\/+$/g, "");
+  discoveredPackageRoots.push(cleanRoot);
 }
 
 /**

--- a/tests/functions/isPackageRootIndex.spec.ts
+++ b/tests/functions/isPackageRootIndex.spec.ts
@@ -1,5 +1,6 @@
 import {
   addToDiscoveredPackageRoots,
+  getDiscoveredPackageRoots,
   isPackageRootIndex,
   resetDiscoveredPackageRoots,
 } from "../../src/functions/isPackageRootIndex";
@@ -34,5 +35,23 @@ describe("Package Root Index Detection", () => {
     addToDiscoveredPackageRoots("src/packageA");
     addToDiscoveredPackageRoots("src/packageB");
     expect(isPackageRootIndex("src/packageC/index.js")).toBe(true);
+  });
+
+  it("should store discovered package roots without leading or trailing slashes", () => {
+    addToDiscoveredPackageRoots("/src/packageA/");
+    addToDiscoveredPackageRoots("/src/packageB");
+    addToDiscoveredPackageRoots("src/packageC/");
+    addToDiscoveredPackageRoots("package-A");
+    addToDiscoveredPackageRoots("/package-B");
+    addToDiscoveredPackageRoots("package-C/");
+
+    expect(getDiscoveredPackageRoots()).toEqual([
+      "src/packageA",
+      "src/packageB",
+      "src/packageC",
+      "package-A",
+      "package-B",
+      "package-C",
+    ]);
   });
 });


### PR DESCRIPTION
This fixes an issue where the discovered package root would be stored without removing leading or trailing slashes.
This would lead to `/package` being stored, while `package` would then be checked.

As a consequence the `isPackageRoot` function would not detect the actual package roots correctly leading to all sub-directories with an `index.js` file being built.
