### PR TITLE
Fixing broken assets identification

### DIFF
--- a/docs/tec-migration.md
+++ b/docs/tec-migration.md
@@ -377,7 +377,7 @@ cd -
 Now check the asset registrations, redirected from the `/src/resoureces` directory to the `/build` one are correct:
 
 ```bash
-php ./node_modules/@stellarwp/tyson/tools/source-updater/find-broken-assets.php "$(pwd)/src"
+php ./node_modules/@stellarwp/tyson/tools/source-updater/find-broken-assets.php "$(pwd)"
 ```
 
 The script will check if JS or CSS assets registered with any one of the following functions exist in the `/build`


### PR DESCRIPTION
Fixing migration tool fix-broken-assets.php

Uses the path that has been passed as the root insead of guessing the current working directory.
Ignores externals scripts.
Instead of guessing that the file in question is using type prefix e.g. in a css or a js directory, tries out both scenarios.