### PR TITLE
feat(functions) resolveExternalToGlobal

### DIFF
--- a/dist/functions/index.js
+++ b/dist/functions/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.preprocessPostcssWithPlugins = exports.usesLoader = exports.modifyRulesInConfig = exports.ruleUsesLoader = exports.prependRuleToRuleInConfig = exports.isPackageRootIndex = exports.exposeEntry = exports.doNotPrefixSVGIdsClasses = exports.compileCustomEntryPoints = exports.buildExternalName = void 0;
+exports.resolveExternalToGlobal = exports.preprocessPostcssWithPlugins = exports.usesLoader = exports.modifyRulesInConfig = exports.ruleUsesLoader = exports.prependRuleToRuleInConfig = exports.isPackageRootIndex = exports.exposeEntry = exports.doNotPrefixSVGIdsClasses = exports.compileCustomEntryPoints = exports.buildExternalName = void 0;
 const buildExternalName_1 = require("./buildExternalName");
 Object.defineProperty(exports, "buildExternalName", { enumerable: true, get: function () { return buildExternalName_1.buildExternalName; } });
 const compileCustomEntryPoints_1 = require("./compileCustomEntryPoints");
@@ -21,3 +21,5 @@ const usesLoader_1 = require("./usesLoader");
 Object.defineProperty(exports, "usesLoader", { enumerable: true, get: function () { return usesLoader_1.usesLoader; } });
 const preprocessPostcssWithPlugins_1 = require("./preprocessPostcssWithPlugins");
 Object.defineProperty(exports, "preprocessPostcssWithPlugins", { enumerable: true, get: function () { return preprocessPostcssWithPlugins_1.preprocessPostcssWithPlugins; } });
+const resolveExternalToGlobal_1 = require("./resolveExternalToGlobal");
+Object.defineProperty(exports, "resolveExternalToGlobal", { enumerable: true, get: function () { return resolveExternalToGlobal_1.resolveExternalToGlobal; } });

--- a/dist/functions/resolveExternalToGlobal.js
+++ b/dist/functions/resolveExternalToGlobal.js
@@ -1,0 +1,37 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.resolveExternalToGlobal = resolveExternalToGlobal;
+/**
+ * Resolves a package request to a global variable name.
+ * This function shoudl be used in the WebPack configuration `externals` property.
+ *
+ *
+ * @since TBD
+ *
+ * @param {string} packagePrefix The prefix to match against the request, e.g., '@tec/package'.
+ * @param {string} packageWindowObjectName The name of the global object in the window, e.g., 'window.tec.package'.
+ *
+ * @return {Function} A function that handles request resolution.
+ */
+function resolveExternalToGlobal(packagePrefix, packageWindowObjectName) {
+    /**
+     * Handles the request resolution, checking if it starts with the package prefix.
+     *
+     * @since TBD
+     *
+     * @param {string} request The import path being requested.
+     * @param {function} callback Callback function used to indicate how the module should be externalized.
+     *
+     * @return {void} The function does not return a value.
+     */
+    return function ({ request }, callback) {
+        if (request.startsWith(packagePrefix)) {
+            const path = request
+                .replace(packagePrefix, "")
+                .replace(/^\//g, "")
+                .replace(/\//g, ".");
+            return callback(null, packageWindowObjectName + (path ? "." + path : ""));
+        }
+        callback();
+    };
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.WindowAssignPropertiesPlugin = exports.preprocessPostcssWithPlugins = exports.usesLoader = exports.modifyRulesInConfig = exports.ruleUsesLoader = exports.prependRuleToRuleInConfig = exports.isPackageRootIndex = exports.exposeEntry = exports.doNotPrefixSVGIdsClasses = exports.compileCustomEntryPoints = exports.buildExternalName = exports.createTECPackage = exports.TECPackage = exports.createTECLegacyBlocksFrontendPostCss = exports.TECLegacyBlocksFrontendPostCss = exports.createTECPostCss = exports.TECPostCss = exports.createTECLegacyJs = exports.TECLegacyJs = void 0;
+exports.WindowAssignPropertiesPlugin = exports.preprocessPostcssWithPlugins = exports.usesLoader = exports.modifyRulesInConfig = exports.ruleUsesLoader = exports.resolveExternalToGlobal = exports.prependRuleToRuleInConfig = exports.isPackageRootIndex = exports.exposeEntry = exports.doNotPrefixSVGIdsClasses = exports.compileCustomEntryPoints = exports.buildExternalName = exports.createTECPackage = exports.TECPackage = exports.createTECLegacyBlocksFrontendPostCss = exports.TECLegacyBlocksFrontendPostCss = exports.createTECPostCss = exports.TECPostCss = exports.createTECLegacyJs = exports.TECLegacyJs = void 0;
 const schema_1 = require("./schema");
 Object.defineProperty(exports, "TECLegacyBlocksFrontendPostCss", { enumerable: true, get: function () { return schema_1.TECLegacyBlocksFrontendPostCss; } });
 Object.defineProperty(exports, "createTECLegacyBlocksFrontendPostCss", { enumerable: true, get: function () { return schema_1.createTECLegacyBlocksFrontendPostCss; } });
@@ -21,5 +21,6 @@ Object.defineProperty(exports, "ruleUsesLoader", { enumerable: true, get: functi
 Object.defineProperty(exports, "modifyRulesInConfig", { enumerable: true, get: function () { return functions_1.modifyRulesInConfig; } });
 Object.defineProperty(exports, "usesLoader", { enumerable: true, get: function () { return functions_1.usesLoader; } });
 Object.defineProperty(exports, "preprocessPostcssWithPlugins", { enumerable: true, get: function () { return functions_1.preprocessPostcssWithPlugins; } });
+Object.defineProperty(exports, "resolveExternalToGlobal", { enumerable: true, get: function () { return functions_1.resolveExternalToGlobal; } });
 const webpack_1 = require("./webpack");
 Object.defineProperty(exports, "WindowAssignPropertiesPlugin", { enumerable: true, get: function () { return webpack_1.WindowAssignPropertiesPlugin; } });

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -88,3 +88,71 @@ This function is particularly useful when:
 2. Keep namespace segments short and meaningful
 3. Use the `dropFrags` parameter to remove common prefixes or suffixes that don't add value to the final name
 4. Maintain consistency in namespace naming across your project 
+
+## resolveExternalToGlobal
+
+The `resolveExternalToGlobal` function is used in Webpack configurations to map package requests to global variable names. It converts namespace paths into a format suitable for external module resolution.
+
+### Syntax
+
+```typescript
+resolveExternalToGlobal(packagePrefix: string, packageWindowObjectName: string): (request: string) => string
+```
+
+### Parameters
+
+- `packagePrefix`: The namespace prefix to match against import requests (e.g., `'@tec/plugin/package'`).
+- `packageWindowObjectName`: The global object name to map to (e.g., `'window.tec.plugin.package'`).
+
+### Examples
+
+#### Basic Usage in Webpack Config
+
+```typescript
+module.exports = {
+  externals: [
+    resolveExternalToGlobal('@tec/plugin/package', 'window.tec.plugin.package'),
+    resolveExternalToGlobal('@tec/another-plugin', 'window.tec.anotherPlugin')
+  ]
+};
+```
+
+#### Request Resolution
+
+For a request like `'@tec/plugin/package/feature'`:
+- Matches `packagePrefix`
+- Becomes `window.tec.plugin.package.feature`
+
+### Use Cases
+
+1. Mapping internal package imports to global variables in Webpack
+2. Simplifying external module resolution for nested namespaces
+3. Consistent naming when exposing modules globally
+
+### Examples
+
+In the Webpack configuration, you can use this function to map specific packages to their respective global variables:
+
+```
+module.exports = {
+  ...defaultConfig,
+  ...{
+    externals:[
+        ...(defaultConfig?.externals || []),
+        resolveExternalToGlobal('@tec/plugin', 'window.tec.plugin'),
+    ],
+  },
+};
+```
+
+In the code reference the `@tec/plugin` namespace:
+
+```js
+import {functionOne} from "@tec/plugin/package";
+import {functionTwo} from "@tec/plugin/package/functions";
+```
+
+### Best Practices
+
+1. Use exact namespace prefixes to avoid unintended matches
+2. Ensure `packageWindowObjectName` matches your global variable structure

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -8,6 +8,7 @@ import { ruleUsesLoader } from "./ruleUsesLoader";
 import { modifyRulesInConfig } from "./modifyRulesInConfig";
 import { usesLoader } from "./usesLoader";
 import { preprocessPostcssWithPlugins } from "./preprocessPostcssWithPlugins";
+import { resolveExternalToGlobal } from "./resolveExternalToGlobal";
 
 export {
   buildExternalName,
@@ -20,4 +21,5 @@ export {
   modifyRulesInConfig,
   usesLoader,
   preprocessPostcssWithPlugins,
+  resolveExternalToGlobal,
 };

--- a/src/functions/resolveExternalToGlobal.ts
+++ b/src/functions/resolveExternalToGlobal.ts
@@ -1,0 +1,37 @@
+/**
+ * Resolves a package request to a global variable name.
+ * This function shoudl be used in the WebPack configuration `externals` property.
+ *
+ *
+ * @since TBD
+ *
+ * @param {string} packagePrefix The prefix to match against the request, e.g., '@tec/package'.
+ * @param {string} packageWindowObjectName The name of the global object in the window, e.g., 'window.tec.package'.
+ *
+ * @return {Function} A function that handles request resolution.
+ */
+export function resolveExternalToGlobal(
+  packagePrefix: string,
+  packageWindowObjectName: string,
+) {
+  /**
+   * Handles the request resolution, checking if it starts with the package prefix.
+   *
+   * @since TBD
+   *
+   * @param {string} request The import path being requested.
+   * @param {function} callback Callback function used to indicate how the module should be externalized.
+   *
+   * @return {void} The function does not return a value.
+   */
+  return function ({ request }: { request: string }, callback): void {
+    if (request.startsWith(packagePrefix)) {
+      const path = request
+        .replace(packagePrefix, "")
+        .replace(/^\//g, "")
+        .replace(/\//g, ".");
+      return callback(null, packageWindowObjectName + (path ? "." + path : ""));
+    }
+    callback();
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   modifyRulesInConfig,
   usesLoader,
   preprocessPostcssWithPlugins,
+  resolveExternalToGlobal,
 } from "./functions";
 import { WindowAssignPropertiesPlugin } from "./webpack";
 
@@ -38,6 +39,7 @@ export {
   exposeEntry,
   isPackageRootIndex,
   prependRuleToRuleInConfig,
+  resolveExternalToGlobal,
   ruleUsesLoader,
   modifyRulesInConfig,
   usesLoader,

--- a/tests/functions/resolveExternalToGlobal.spec.ts
+++ b/tests/functions/resolveExternalToGlobal.spec.ts
@@ -1,0 +1,73 @@
+import { resolveExternalToGlobal } from "../../src/functions/resolveExternalToGlobal";
+
+describe("resolveExternalToGlobal", () => {
+  it("should resolve request to global name when matches prefix", () => {
+    const packagePrefix = "@tec/package";
+    const packageWindowObjectName = "window.tec.package";
+    const resolveFn = resolveExternalToGlobal(
+      packagePrefix,
+      packageWindowObjectName,
+    );
+
+    const callback = jest.fn();
+    resolveFn({ request: "@tec/package/src/index" }, callback);
+
+    expect(callback).toHaveBeenCalledWith(null, "window.tec.package.src.index");
+  });
+
+  it("should not resolve if request does not match prefix", () => {
+    const packagePrefix = "@tec/package";
+    const packageWindowObjectName = "window.tec.package";
+    const resolveFn = resolveExternalToGlobal(
+      packagePrefix,
+      packageWindowObjectName,
+    );
+
+    const callback = jest.fn();
+    resolveFn({ request: "other/package" }, callback);
+
+    expect(callback).toHaveBeenCalledWith();
+  });
+
+  it("should handle request exactly matching the package prefix", () => {
+    const packagePrefix = "@tec/package";
+    const packageWindowObjectName = "window.tec.package";
+    const resolveFn = resolveExternalToGlobal(
+      packagePrefix,
+      packageWindowObjectName,
+    );
+
+    const callback = jest.fn();
+    resolveFn({ request: "@tec/package" }, callback);
+
+    expect(callback).toHaveBeenCalledWith(null, "window.tec.package");
+  });
+
+  it("should handle request with multiple slashes", () => {
+    const packagePrefix = "@tec/package";
+    const packageWindowObjectName = "window.tec.package";
+    const resolveFn = resolveExternalToGlobal(
+      packagePrefix,
+      packageWindowObjectName,
+    );
+
+    const callback = jest.fn();
+    resolveFn({ request: "@tec/package/abc/def" }, callback);
+
+    expect(callback).toHaveBeenCalledWith(null, "window.tec.package.abc.def");
+  });
+
+  it("should handle empty request", () => {
+    const packagePrefix = "@tec/package";
+    const packageWindowObjectName = "window.tec.package";
+    const resolveFn = resolveExternalToGlobal(
+      packagePrefix,
+      packageWindowObjectName,
+    );
+
+    const callback = jest.fn();
+    resolveFn({ request: "" }, callback);
+
+    expect(callback).toHaveBeenCalledWith();
+  });
+});


### PR DESCRIPTION
Add a function that makes it easy to add external resolution to global
variables in the webpack configuration file.

In the webpack configuration file:
```
module.exports = {
    ...defaultConfig,
    ...{
    externals:[
        ...(defaultConfig?.externals || []),
        resolveExternalToGlobal('@tec/plugin/package', 'window.tec.plugin.package'),
    ],
  },
};
```

In the code:

```js
import {someFunction} from "@tec/plugin/package/functions";
```

I've tested this out in the Classy project to resolve the `@tec/common/classy` namespace to `window.tec.common.classy` and it works as expected.
