### PR TITLE
Update TECPostCss.ts to allow passing preprocess plugins.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellarwp/tyson",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellarwp/tyson",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Create and manage custom configurations to build projects with @wordpress/scripts.",
   "main": "dist/index.js",
   "bin": {

--- a/src/schema/TECPostCss.ts
+++ b/src/schema/TECPostCss.ts
@@ -44,14 +44,16 @@ export function createTECPostCss(
    */
   function modifyConfig(config: WebPackConfiguration): void {
     preprocessPostcssWithPlugins(
-      config, 
+      config,
       [
         "postcss-nested",
         "postcss-preset-env",
         "postcss-mixins",
         "postcss-import",
         "postcss-custom-media",
-      ].concat( preprocessPlugins ).filter((e, i,self ) => i === self.indexOf(e))
+      ]
+        .concat(preprocessPlugins)
+        .filter((e, i, self) => i === self.indexOf(e)),
     );
   }
 

--- a/src/schema/TECPostCss.ts
+++ b/src/schema/TECPostCss.ts
@@ -11,6 +11,7 @@ import { preprocessPostcssWithPlugins } from "../functions";
  */
 export function createTECPostCss(
   namespace: string | string[] = "tec",
+  preprocessPlugins: string | string[] = [],
 ): ConfigurationSchema {
   /**
    * Determines if a file should be included based on its name.
@@ -37,16 +38,21 @@ export function createTECPostCss(
    * PostCSS plugins to unroll the code. These plugins, applied before the `autoprefixer` one, will make the PostCSS code
    * digestable for the `autoprefixer` plugin and the following ones.
    *
+   * Additional plugins can be passed to the createTECPostCss function as the second param `preprocessPlugins`
+   *
    * @param {WebPackConfiguration} config - The WebPack configuration object to be modified.
    */
   function modifyConfig(config: WebPackConfiguration): void {
-    preprocessPostcssWithPlugins(config, [
-      "postcss-nested",
-      "postcss-preset-env",
-      "postcss-mixins",
-      "postcss-import",
-      "postcss-custom-media",
-    ]);
+    preprocessPostcssWithPlugins(
+      config, 
+      [
+        "postcss-nested",
+        "postcss-preset-env",
+        "postcss-mixins",
+        "postcss-import",
+        "postcss-custom-media",
+      ].concat( preprocessPlugins ).filter((e, i,self ) => i === self.indexOf(e))
+    );
   }
 
   return {


### PR DESCRIPTION
This allows us to pass any specific requirements to the build process - such as the `postcss-inline-svg` plugin.