### PR TITLE
Update publish.yml to use trusted published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,14 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
-
+# This uses OIDC Trusted Publishing: https://docs.npmjs.com/trusted-publishers
 name: Publish package on npm
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
 
 jobs:
   build:
@@ -52,11 +54,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+
+      # We need to use npm for trusted publishing.
+      - name: Set up node
+        uses: actions/setup-node@v4
         with:
           node-version: 18.17.0
-          registry-url: https://registry.npmjs.org/
+          registry-url: 'https://registry.npmjs.org'
+
       - run: npm ci
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      # npm >=11.5.1 automatically supports OIDC trusted publishing.
+      - name: Publish package to NPM
+        run: npm publish --verbose --access public


### PR DESCRIPTION
This updates the `publish.yml` workflow file to use the trusted publisher system to publish to `npm` registry.
Note that I've already updated the package Settings on npmjs.com to use GitHub Actions as a trusted publisher.

Note about the required `npm` version:
```bash
$ nvm use
Now using node v18.17.0 (npm v11.6.1)
```
So, the `npm` vesion is `>=11.5.1` and it should be fine.